### PR TITLE
allow custom action after URL is acquired

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A script using selenium to collect URLs to Google Hangouts.
      * `seleniumPort`: Port to which selenium standalone server should bind.
      * `seleniumVerboseLogging`: set to `true` to enable verbose logging of the selenium process.
      * `seleniumJarVersion`: The version of the selenium standalone server jar to download if not present.
+     * `urlAcquiredCallback`: An optional function to call after acquiring a Hangout URL. A single argument is passed, which is the acquired hangout URL.
 
 ## Usage
 

--- a/conf.js.example
+++ b/conf.js.example
@@ -14,4 +14,5 @@ module.exports = {
     "seleniumPort": 4444,
     "seleniumVerboseLogging": false,
     "seleniumJarVersion": "2.53.0",
+    // "urlAcquiredCallback": function(url) {},
 }

--- a/index.js
+++ b/index.js
@@ -144,7 +144,11 @@ function getNextLink(driver, count) {
     driver.findElement(linkSel).then(function(el) {
       return el.getAttribute("value").then(function(value) {
         if (value) {
-          console.log(value && value.replace("/call/", "/hangouts/_/"));
+          var url = value.replace("/call/", "/hangouts/_/");
+          console.log(url);
+          if (typeof conf.urlAcquiredCallback === 'function') {
+            conf.urlAcquiredCallback(url);
+          }
           if (count > 0) {
             getNextLink(driver, count - 1);
           }


### PR DESCRIPTION
adds urlAcquiredCallback key to config, which allows a custom
action to be performed via a callback function after a hangout
URL is acquired.
